### PR TITLE
Fix the possibility of inaccurate distance calculation and easy misoperation of shortcut keys

### DIFF
--- a/scripting/player-pings.sp
+++ b/scripting/player-pings.sp
@@ -660,6 +660,12 @@ Action Timer_UpdateInstructorAll(Handle timer, DataPack data)
 
 	float pos[3];
 	data.ReadFloatArray(pos, sizeof(pos));
+	// If in the player's inventory, the location of the entity is fixed to where it was when it was picked up.
+	// Todo: What should be obtained is the player's position
+	if( IsValidEntity(entity) )
+	{
+		GetEntityAbsOrigin(entity, pos);
+	}
 
 	int color[3];
 	data.ReadCellArray(color, sizeof(color));


### PR DESCRIPTION
Fix inaccurate distance calculation when marked items are moving or in player inventory
Fix Combination keys (or shortcut keys) Easy to misoperate in #5 
Remove unnecessary GetEntityClassname